### PR TITLE
fix: replace swapOrder with bulk reorder endpoint

### DIFF
--- a/src/modules/content/content.controller.ts
+++ b/src/modules/content/content.controller.ts
@@ -121,13 +121,13 @@ export class ContentController {
     return await this.service.getById(id);
   }
 
-  @Patch('swap-order')
+  @Patch('reorder')
   @ApiResponse({
     status: 200,
-    description: 'ordem de dois conteúdos trocada',
+    description: 'ordem dos conteúdos atualizada',
   })
-  async swapOrder(@Body() body: { id1: string; id2: string }): Promise<void> {
-    return await this.service.swapOrder(body.id1, body.id2);
+  async reorder(@Body() body: { orderedIds: string[] }): Promise<void> {
+    return await this.service.reorder(body.orderedIds);
   }
 
   @Patch(':id/status')

--- a/src/modules/content/content.repository.ts
+++ b/src/modules/content/content.repository.ts
@@ -104,6 +104,16 @@ export class ContentRepository extends BaseRepository<Content> {
     return !existing;
   }
 
+  async bulkUpdateOrder(items: { id: string; order: number }[]): Promise<void> {
+    const ops = items.map(({ id, order }) => ({
+      updateOne: {
+        filter: { _id: id },
+        update: { $set: { order } },
+      },
+    }));
+    await this.model.bulkWrite(ops);
+  }
+
   async countByStatus(status: StatusContent): Promise<number> {
     return this.model.countDocuments({ status, deleted: { $ne: true } });
   }

--- a/src/modules/content/content.service.ts
+++ b/src/modules/content/content.service.ts
@@ -97,17 +97,9 @@ export class ContentService {
     );
   }
 
-  async swapOrder(id1: string, id2: string): Promise<void> {
-    const content1 = await this.repository.getById(id1);
-    const content2 = await this.repository.getById(id2);
-    if (!content1 || !content2) {
-      throw new HttpException('Conteúdo não encontrado', HttpStatus.NOT_FOUND);
-    }
-    const tempOrder = content1.order;
-    content1.order = content2.order;
-    content2.order = tempOrder;
-    await this.repository.update(content1);
-    await this.repository.update(content2);
+  async reorder(orderedIds: string[]): Promise<void> {
+    const items = orderedIds.map((id, index) => ({ id, order: index }));
+    await this.repository.bulkUpdateOrder(items);
   }
 
   async delete(id: string): Promise<void> {


### PR DESCRIPTION
Replace the swap-order endpoint (which only swapped 2 items) with a reorder endpoint that accepts the full ordered list of IDs and updates all positions via bulkWrite.