### PR TITLE
ci: add concurrency to cancel outdated develop workflows

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -4,6 +4,10 @@ on:
     branches: ["develop"]
     types: [opened, synchronize, reopened, closed]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CI:
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')


### PR DESCRIPTION
When multiple PRs merge to develop, only the latest pipeline runs. Previous in-progress runs are automatically cancelled.