### PR TITLE
ci: migrar deploy de produção para fluxo baseado em tags

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  categories:
+    - title: "🚀 Features"
+      labels:
+        - enhancement
+        - feature
+    - title: "🐛 Bug Fixes"
+      labels:
+        - bug
+        - fix
+    - title: "🔧 Manutenção"
+      labels:
+        - chore
+        - refactor
+        - dependencies
+    - title: "📝 Documentação"
+      labels:
+        - documentation
+    - title: "Outros"
+      labels:
+        - "*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,17 @@
-name: msSimulado
+# =============================================================================
+# main - CI only (deploy é feito via tag no release.yml)
+# =============================================================================
+
+name: CI Main
+
 on:
   pull_request:
-    branches: ["main"]
-    types: [opened, synchronize, reopened, closed]
+    branches: ['main']
+    types: [opened, synchronize, reopened]
 
 jobs:
   CI:
-    if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
     runs-on: ubuntu-latest
-
     services:
       mongodb:
         image: mongo:7
@@ -30,42 +33,3 @@ jobs:
         env:
           NODE_ENV: test
           MONGODB: mongodb://localhost:27017/ms-simulado-test
-  PUSH:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    steps:
-      # Checkout main para a imagem refletir o estado da branch em produção
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-          cache: yarn
-      - name: Install depends
-        run: yarn
-      - name: Build app MS Simulado
-        run: yarn build
-      - name: Build Image
-        run: docker build -t mssimulado -f ms.dockerfile .
-      - name: docker tags
-        run: docker tag mssimulado vcnafacul/simulado:stable
-      - name: docker login
-        run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
-      - name: Image Push
-        run: docker push vcnafacul/simulado:stable
-  DEPLOY_PROD:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.base_ref == 'main'
-    needs: PUSH
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy em Produção (Hostinger)
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.DEPLOY_HOST_PROD }}
-          username: ${{ secrets.DEPLOY_USER_PROD }}
-          password: ${{ secrets.DEPLOY_PASS_PROD }}
-          script: |
-            chmod +x ~/subir_ms.sh
-            ~/subir_ms.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+# =============================================================================
+# release - Build, Deploy Production & Create GitHub Release
+# =============================================================================
+# Disparado por push de tag (ex: git tag v1.2.0 && git push origin v1.2.0)
+# 1. Build + push Docker image (tag versão + :stable)
+# 2. Deploy em produção via SSH
+# 3. Cria Release no GitHub com changelog automático (PRs entre tags)
+# =============================================================================
+
+name: Release & Deploy Production
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  BUILD_AND_PUSH:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: yarn
+
+      - name: Install depends
+        run: yarn
+
+      - name: Build app MS Simulado
+        run: yarn build
+
+      - name: Build Docker image
+        run: |
+          docker build -t vcnafacul/simulado:${{ github.ref_name }} \
+                        -t vcnafacul/simulado:stable \
+                        -f ms.dockerfile .
+
+      - name: Docker login
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin
+
+      - name: Push Docker image
+        run: |
+          docker push vcnafacul/simulado:${{ github.ref_name }}
+          docker push vcnafacul/simulado:stable
+
+  DEPLOY_PROD:
+    needs: BUILD_AND_PUSH
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy em Produção (Hostinger)
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST_PROD }}
+          username: ${{ secrets.DEPLOY_USER_PROD }}
+          password: ${{ secrets.DEPLOY_PASS_PROD }}
+          script: |
+            chmod +x ~/subir_ms.sh
+            ~/subir_ms.sh
+
+  CREATE_RELEASE:
+    needs: DEPLOY_PROD
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          tag_name: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- main.yml agora faz apenas CI (build + testes)
- Novo release.yml: disparado por push de tag v*, faz build Docker, deploy em produção e cria GitHub Release com changelog automático
- Novo .github/release.yml: categoriza PRs por labels no changelog