### PR TITLE
chore: optimize Dockerfile with multi-stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.git
+.env*
+*.log
+.vscode
+.idea

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy em Homolog (Oracle VPS)
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.DEPLOY_HOST_HOMOL }}
           username: ${{ secrets.DEPLOY_USER_HOMOL }}

--- a/ms.dockerfile
+++ b/ms.dockerfile
@@ -1,16 +1,22 @@
-FROM node:20.18.2-alpine
+FROM node:20-alpine AS deps
 
-COPY dist /var/www
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+
+RUN yarn install --production --frozen-lockfile && yarn cache clean
+
+FROM node:20-alpine
 
 WORKDIR /var/www
 
+COPY --from=deps /app/node_modules ./node_modules
+COPY dist ./
 COPY package.json .
-COPY yarn.lock .
+
+ARG NODE_ENV=production
+ENV NODE_ENV=$NODE_ENV
 
 EXPOSE 3000
 
-ENV NODE_ENV=$NODE_ENV
-
-RUN yarn install --production && yarn cache clean
-
-CMD ./node_modules/pm2/bin/pm2-runtime main.js --name msSimulado
+CMD ["./node_modules/pm2/bin/pm2-runtime", "main.js", "--name", "msSimulado"]


### PR DESCRIPTION
Use multi-stage build to isolate dependency installation, exec form CMD, proper ARG/ENV for NODE_ENV, and add .dockerignore.