### PR TITLE
docs: rewrite README with scope, stack and siblings overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,113 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="200" alt="Nest Logo" /></a>
-</p>
+# 🧠 Você na Facul — ms-simulado
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
+Microsserviço responsável pelo **motor de simulados (provas)** da plataforma **Você na Facul**.
 
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://coveralls.io/github/nestjs/nest?branch=master" target="_blank"><img src="https://coveralls.io/repos/github/nestjs/nest/badge.svg?branch=master#9" alt="Coverage" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+Cuida do banco de questões, montagem de provas (simulados, ENEM), aplicação, respostas, correção automática e relatórios de desempenho. **Não é exposto ao público**: só recebe chamadas do gateway `api-vcnafacul`.
 
-## Description
+---
 
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+## 🧩 Arquitetura
 
-## Installation
-
-```bash
-$ pnpm install
+```
+client-vcnafacul  →  api-vcnafacul  →  ms-simulado       ← você está aqui
+  (React SPA)       (NestJS gateway)   (NestJS + MongoDB)
+                         ↓
+                    vcnafacul-form    (construtor de formulários)
+                    (NestJS + MongoDB)
 ```
 
-## Running the app
+| Serviço | Stack | Banco | Porta |
+|---------|-------|-------|-------|
+| api-vcnafacul | NestJS 10 + TypeORM | MySQL 8+ | `3333` |
+| **ms-simulado** (este) | NestJS 10 + Mongoose | MongoDB | `3000` |
+| vcnafacul-form | NestJS 11 + Mongoose | MongoDB | `3001` |
+| client-vcnafacul | React 19 + Vite 6 | — | `5173` |
+
+---
+
+## 🛠 Tecnologias
+
+- **NestJS 10** (TypeScript)
+- **MongoDB** + **Mongoose**
+- **BaseService** genérico com cache embutido
+- **Swagger** em `/api`
+- **Class-Validator** / **Class-Transformer**
+- **Jest** (unit + e2e)
+
+---
+
+## 📂 Domínio
+
+Principais bounded contexts:
+
+- **Questão** — enunciado, alternativas, gabarito, metadados (matéria, frente, ano, prova)
+- **Simulado** — montagem de prova a partir do banco de questões
+- **Resposta / Aplicação** — registro de respostas de estudantes e correção
+- **Relatório** — estatísticas de acertos por matéria/frente
+
+Termos em português: _simulado_ (prova), _frente_ (subárea), _matéria_ (disciplina), _questão_ (pergunta), _prova_ (exame origem).
+
+---
+
+## ⚙️ Pré-requisitos
+
+- Node.js 20+
+- Yarn
+- MongoDB 6+
+
+---
+
+## 🚀 Setup
 
 ```bash
-# development
-$ pnpm run start
+# Instalar dependências
+yarn
 
-# watch mode
-$ pnpm run start:dev
+# Copiar .env e preencher
+cp .env.example .env
+# NODE_ENV, MONGODB, PORT
 
-# production mode
-$ pnpm run start:prod
+# Subir em modo watch (porta 3000)
+yarn dev
 ```
 
-## Test
+---
+
+## 📑 Documentação da API
+
+Swagger disponível em:
+
+```
+http://localhost:3000/api
+```
+
+---
+
+## 🧪 Testes
 
 ```bash
-# unit tests
-$ pnpm run test
+# Unit
+yarn test
 
-# e2e tests
-$ pnpm run test:e2e
+# e2e
+yarn test:e2e
 
-# test coverage
-$ pnpm run test:cov
+# cobertura
+yarn test:cov
+
+# Um arquivo específico (flags extras ajudam com handles abertos)
+npx jest --detectOpenHandles --forceExit path/to/file.spec.ts
 ```
 
-## Support
+---
 
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
+## 🔀 CI/CD
 
-## Stay in touch
+- `ci-homol.yml` — deploy em homologação ao mergear PR em `develop`
+- `ci-prod.yml` — deploy em produção ao publicar tag `v*`
 
-- Author - [Kamil Myśliwiec](https://kamilmysliwiec.com)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
+---
 
-## License
+## 📄 Licença
 
-Nest is [MIT licensed](LICENSE).
+MIT.


### PR DESCRIPTION
## Summary
- Rewrites README to reflect what this service actually does within the **Você na Facul** platform
- Adds an architecture diagram and a table showing sibling services (client, api, ms-simulado, form) with stack, DB and port
- Lists prerequisites, env vars, setup steps and common scripts
- References the new CI workflows (`ci-homol.yml`, `ci-prod.yml`)
- Ports standardized: `ms-simulado` = 3000, `vcnafacul-form` = 3001

## Test plan
- [ ] Preview the README on GitHub and confirm diagram/table render correctly
- [ ] Verify commands and env variable names match the current codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)