### PR TITLE
feat(user-group-aggregates): Fase A — monthly performance snapshots by class

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 import { AdjustmentProposalModule } from './modules/adjustment-proposal/adjustment-proposal.module';
+import { UserGroupAggregateModule } from './modules/user-group-aggregates/user-group-aggregate.module';
 import { ContentModule } from './modules/content/content.module';
 import { ContentFileHistoryModule } from './modules/content-file-history/content-file-history.module';
 import { ExameModule } from './modules/exame/exame.module';
@@ -45,6 +46,7 @@ import { Env, envSchema } from './shared/modules/env/env';
     ContentFileHistoryModule,
     FileContentModule,
     AdjustmentProposalModule,
+    UserGroupAggregateModule,
   ],
   providers: [],
 })

--- a/src/modules/user-group-aggregates/dtos/calculate-aggregate.dto.input.ts
+++ b/src/modules/user-group-aggregates/dtos/calculate-aggregate.dto.input.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsDateString,
+  IsIn,
+  IsString,
+  ArrayNotEmpty,
+  Matches,
+} from 'class-validator';
+
+export class CalculateAggregateDtoInput {
+  @ApiProperty()
+  @IsString()
+  groupId: string;
+
+  @ApiProperty({ enum: ['class'] })
+  @IsIn(['class'])
+  groupType: 'class';
+
+  @ApiProperty({ example: '2026-05' })
+  @Matches(/^\d{4}-\d{2}$/)
+  month: string;
+
+  @ApiProperty()
+  @IsDateString()
+  monthStart: string;
+
+  @ApiProperty()
+  @IsDateString()
+  monthEnd: string;
+
+  @ApiProperty({ type: [String] })
+  @IsArray()
+  @ArrayNotEmpty()
+  userIds: string[];
+}

--- a/src/modules/user-group-aggregates/dtos/get-by-month.dto.input.ts
+++ b/src/modules/user-group-aggregates/dtos/get-by-month.dto.input.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsString, Matches } from 'class-validator';
+
+export class GetByMonthDtoInput {
+  @ApiProperty()
+  @IsString()
+  groupId: string;
+
+  @ApiProperty({ enum: ['class'] })
+  @IsIn(['class'])
+  groupType: 'class';
+
+  @ApiProperty({ example: '2026-05' })
+  @Matches(/^\d{4}-\d{2}$/)
+  month: string;
+}

--- a/src/modules/user-group-aggregates/dtos/list-aggregates.dto.input.ts
+++ b/src/modules/user-group-aggregates/dtos/list-aggregates.dto.input.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsString } from 'class-validator';
+
+export class ListAggregatesDtoInput {
+  @ApiProperty()
+  @IsString()
+  groupId: string;
+
+  @ApiProperty({ enum: ['class'] })
+  @IsIn(['class'])
+  groupType: 'class';
+}

--- a/src/modules/user-group-aggregates/dtos/user-group-aggregate.dto.output.ts
+++ b/src/modules/user-group-aggregates/dtos/user-group-aggregate.dto.output.ts
@@ -1,0 +1,84 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FrenteAggregateDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  nome: string;
+
+  @ApiProperty()
+  aproveitamento: number;
+
+  @ApiProperty()
+  studentsContributing: number;
+
+  @ApiProperty()
+  attemptsContributing: number;
+}
+
+export class MateriaAggregateDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  nome: string;
+
+  @ApiProperty()
+  aproveitamento: number;
+
+  @ApiProperty()
+  studentsContributing: number;
+
+  @ApiProperty()
+  attemptsContributing: number;
+
+  @ApiProperty({ type: [FrenteAggregateDto] })
+  frentes: FrenteAggregateDto[];
+}
+
+export class AggregatePayloadDto {
+  @ApiProperty()
+  geral: number;
+
+  @ApiProperty()
+  totalAttempts: number;
+
+  @ApiProperty()
+  totalAttemptsCompleted: number;
+
+  @ApiProperty()
+  studentsWithAtLeastOneCompletedAttempt: number;
+
+  @ApiProperty({ type: [MateriaAggregateDto] })
+  materias: MateriaAggregateDto[];
+}
+
+export class UserGroupAggregateDtoOutput {
+  @ApiProperty()
+  groupId: string;
+
+  @ApiProperty()
+  groupType: 'class';
+
+  @ApiProperty({ example: '2026-05' })
+  month: string;
+
+  @ApiProperty()
+  monthStart: Date;
+
+  @ApiProperty()
+  monthEnd: Date;
+
+  @ApiProperty({ type: [String] })
+  userIds: string[];
+
+  @ApiProperty()
+  generatedAt: Date;
+
+  @ApiProperty()
+  sourceHistoricoCount: number;
+
+  @ApiProperty()
+  payload: AggregatePayloadDto;
+}

--- a/src/modules/user-group-aggregates/user-group-aggregate.controller.ts
+++ b/src/modules/user-group-aggregates/user-group-aggregate.controller.ts
@@ -1,9 +1,10 @@
 import { Body, Controller, Get, Post, Query } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UserGroupAggregateService } from './user-group-aggregate.service';
 import { CalculateAggregateDtoInput } from './dtos/calculate-aggregate.dto.input';
 import { GetByMonthDtoInput } from './dtos/get-by-month.dto.input';
 import { ListAggregatesDtoInput } from './dtos/list-aggregates.dto.input';
+import { UserGroupAggregateDtoOutput } from './dtos/user-group-aggregate.dto.output';
 
 @ApiTags('UserGroupAggregates')
 @Controller('v1/user-group-aggregates')
@@ -11,16 +12,20 @@ export class UserGroupAggregateController {
   constructor(private readonly service: UserGroupAggregateService) {}
 
   @Get()
+  @ApiResponse({ status: 200, type: [UserGroupAggregateDtoOutput] })
   async list(@Query() q: ListAggregatesDtoInput) {
     return this.service.list(q.groupId, q.groupType);
   }
 
   @Get('by-month')
+  @ApiResponse({ status: 200, type: UserGroupAggregateDtoOutput })
+  @ApiResponse({ status: 404, description: 'Aggregate not found for this month' })
   async byMonth(@Query() q: GetByMonthDtoInput) {
     return this.service.findByMonth(q.groupId, q.groupType, q.month);
   }
 
   @Post('calculate')
+  @ApiResponse({ status: 201, type: UserGroupAggregateDtoOutput })
   async calculate(@Body() dto: CalculateAggregateDtoInput) {
     return this.service.calculate(dto);
   }

--- a/src/modules/user-group-aggregates/user-group-aggregate.controller.ts
+++ b/src/modules/user-group-aggregates/user-group-aggregate.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { UserGroupAggregateService } from './user-group-aggregate.service';
+import { CalculateAggregateDtoInput } from './dtos/calculate-aggregate.dto.input';
+import { GetByMonthDtoInput } from './dtos/get-by-month.dto.input';
+import { ListAggregatesDtoInput } from './dtos/list-aggregates.dto.input';
+
+@ApiTags('UserGroupAggregates')
+@Controller('v1/user-group-aggregates')
+export class UserGroupAggregateController {
+  constructor(private readonly service: UserGroupAggregateService) {}
+
+  @Get()
+  async list(@Query() q: ListAggregatesDtoInput) {
+    return this.service.list(q.groupId, q.groupType);
+  }
+
+  @Get('by-month')
+  async byMonth(@Query() q: GetByMonthDtoInput) {
+    return this.service.findByMonth(q.groupId, q.groupType, q.month);
+  }
+
+  @Post('calculate')
+  async calculate(@Body() dto: CalculateAggregateDtoInput) {
+    return this.service.calculate(dto);
+  }
+}

--- a/src/modules/user-group-aggregates/user-group-aggregate.module.ts
+++ b/src/modules/user-group-aggregates/user-group-aggregate.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import {
+  Historico,
+  HistoricoSchema,
+} from '../historico/historico.schema';
+import {
+  UserGroupAggregate,
+  UserGroupAggregateSchema,
+} from './user-group-aggregate.schema';
+import { UserGroupAggregateController } from './user-group-aggregate.controller';
+import { UserGroupAggregateRepository } from './user-group-aggregate.repository';
+import { UserGroupAggregateService } from './user-group-aggregate.service';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: UserGroupAggregate.name, schema: UserGroupAggregateSchema },
+      { name: Historico.name, schema: HistoricoSchema },
+    ]),
+  ],
+  controllers: [UserGroupAggregateController],
+  providers: [UserGroupAggregateRepository, UserGroupAggregateService],
+  exports: [UserGroupAggregateService],
+})
+export class UserGroupAggregateModule {}

--- a/src/modules/user-group-aggregates/user-group-aggregate.repository.ts
+++ b/src/modules/user-group-aggregates/user-group-aggregate.repository.ts
@@ -2,28 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Historico } from '../historico/historico.schema';
-import { UserGroupAggregate } from './user-group-aggregate.schema';
+import { AggregatePayload, UserGroupAggregate } from './user-group-aggregate.schema';
 
-export interface AggregatePayload {
-  geral: number;
-  totalAttempts: number;
-  totalAttemptsCompleted: number;
-  studentsWithAtLeastOneCompletedAttempt: number;
-  materias: {
-    id: string;
-    nome: string;
-    aproveitamento: number;
-    studentsContributing: number;
-    attemptsContributing: number;
-    frentes: {
-      id: string;
-      nome: string;
-      aproveitamento: number;
-      studentsContributing: number;
-      attemptsContributing: number;
-    }[];
-  }[];
-}
+export { AggregatePayload };
 
 @Injectable()
 export class UserGroupAggregateRepository {
@@ -90,28 +71,13 @@ export class UserGroupAggregateRepository {
     const [facetResult] = await this.histModel.aggregate([
       { $match: baseMatch },
       {
-        $lookup: {
-          from: 'simulados',
-          localField: 'simulado',
-          foreignField: '_id',
-          as: 'simuladoDoc',
-        },
-      },
-      { $unwind: '$simuladoDoc' },
-      {
-        $addFields: {
-          isCompleted: {
-            $eq: [
-              '$questoesRespondidas',
-              { $size: '$simuladoDoc.questoes' },
-            ],
-          },
+        $match: {
+          $expr: { $eq: [{ $size: '$respostas' }, '$questoesRespondidas'] },
         },
       },
       {
         $facet: {
           completedRows: [
-            { $match: { isCompleted: true } },
             { $unwind: '$aproveitamento.materias' },
             { $unwind: '$aproveitamento.materias.frentes' },
             {
@@ -130,12 +96,8 @@ export class UserGroupAggregateRepository {
               },
             },
           ],
-          completedCount: [
-            { $match: { isCompleted: true } },
-            { $count: 'total' },
-          ],
+          completedCount: [{ $count: 'total' }],
           completedUsers: [
-            { $match: { isCompleted: true } },
             { $group: { _id: '$usuario' } },
             { $count: 'total' },
           ],

--- a/src/modules/user-group-aggregates/user-group-aggregate.repository.ts
+++ b/src/modules/user-group-aggregates/user-group-aggregate.repository.ts
@@ -1,0 +1,257 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Historico } from '../historico/historico.schema';
+import { UserGroupAggregate } from './user-group-aggregate.schema';
+
+export interface AggregatePayload {
+  geral: number;
+  totalAttempts: number;
+  totalAttemptsCompleted: number;
+  studentsWithAtLeastOneCompletedAttempt: number;
+  materias: {
+    id: string;
+    nome: string;
+    aproveitamento: number;
+    studentsContributing: number;
+    attemptsContributing: number;
+    frentes: {
+      id: string;
+      nome: string;
+      aproveitamento: number;
+      studentsContributing: number;
+      attemptsContributing: number;
+    }[];
+  }[];
+}
+
+@Injectable()
+export class UserGroupAggregateRepository {
+  constructor(
+    @InjectModel(UserGroupAggregate.name)
+    private readonly aggModel: Model<UserGroupAggregate>,
+    @InjectModel(Historico.name)
+    private readonly histModel: Model<Historico>,
+  ) {}
+
+  async findOneByMonth(
+    groupId: string,
+    groupType: 'class',
+    month: string,
+  ): Promise<UserGroupAggregate | null> {
+    return this.aggModel.findOne({ groupId, groupType, month }).lean();
+  }
+
+  async listByGroup(
+    groupId: string,
+    groupType: 'class',
+  ): Promise<UserGroupAggregate[]> {
+    return this.aggModel
+      .find({ groupId, groupType })
+      .sort({ month: -1 })
+      .lean();
+  }
+
+  async upsert(doc: Partial<UserGroupAggregate>): Promise<UserGroupAggregate> {
+    return this.aggModel
+      .findOneAndUpdate(
+        { groupId: doc.groupId, groupType: doc.groupType, month: doc.month },
+        { $set: doc },
+        { new: true, upsert: true },
+      )
+      .lean();
+  }
+
+  async aggregateMonth(input: {
+    userIds: string[];
+    monthStart: Date;
+    monthEnd: Date;
+  }): Promise<{ payload: AggregatePayload }> {
+    if (input.userIds.length === 0) {
+      return {
+        payload: {
+          geral: 0,
+          totalAttempts: 0,
+          totalAttemptsCompleted: 0,
+          studentsWithAtLeastOneCompletedAttempt: 0,
+          materias: [],
+        },
+      };
+    }
+
+    const baseMatch = {
+      usuario: { $in: input.userIds },
+      createdAt: { $gte: input.monthStart, $lte: input.monthEnd },
+      deleted: { $ne: true },
+    };
+
+    const totalAttempts = await this.histModel.countDocuments(baseMatch);
+
+    const [facetResult] = await this.histModel.aggregate([
+      { $match: baseMatch },
+      {
+        $lookup: {
+          from: 'simulados',
+          localField: 'simulado',
+          foreignField: '_id',
+          as: 'simuladoDoc',
+        },
+      },
+      { $unwind: '$simuladoDoc' },
+      {
+        $addFields: {
+          isCompleted: {
+            $eq: [
+              '$questoesRespondidas',
+              { $size: '$simuladoDoc.questoes' },
+            ],
+          },
+        },
+      },
+      {
+        $facet: {
+          completedRows: [
+            { $match: { isCompleted: true } },
+            { $unwind: '$aproveitamento.materias' },
+            { $unwind: '$aproveitamento.materias.frentes' },
+            {
+              $group: {
+                _id: {
+                  usuario: '$usuario',
+                  materiaId: '$aproveitamento.materias.id',
+                  materiaNome: '$aproveitamento.materias.nome',
+                  frenteId: '$aproveitamento.materias.frentes.id',
+                  frenteNome: '$aproveitamento.materias.frentes.nome',
+                },
+                avg: {
+                  $avg: '$aproveitamento.materias.frentes.aproveitamento',
+                },
+                attempts: { $sum: 1 },
+              },
+            },
+          ],
+          completedCount: [
+            { $match: { isCompleted: true } },
+            { $count: 'total' },
+          ],
+          completedUsers: [
+            { $match: { isCompleted: true } },
+            { $group: { _id: '$usuario' } },
+            { $count: 'total' },
+          ],
+        },
+      },
+    ]);
+
+    return { payload: this.buildPayload(facetResult, { totalAttempts }) };
+  }
+
+  private buildPayload(
+    facetResult: {
+      completedRows: any[];
+      completedCount: any[];
+      completedUsers: any[];
+    },
+    meta: { totalAttempts: number },
+  ): AggregatePayload {
+    const { completedRows, completedCount, completedUsers } = facetResult;
+    const totalAttemptsCompleted = completedCount[0]?.total ?? 0;
+    const studentsWithAtLeastOneCompletedAttempt =
+      completedUsers[0]?.total ?? 0;
+
+    const materiaMap = new Map<
+      string,
+      {
+        id: string;
+        nome: string;
+        frenteMap: Map<
+          string,
+          {
+            id: string;
+            nome: string;
+            studentAvgs: number[];
+            attempts: number;
+          }
+        >;
+        studentIds: Set<string>;
+      }
+    >();
+
+    for (const row of completedRows) {
+      const { materiaId, materiaNome, frenteId, frenteNome, usuario } = row._id;
+
+      if (!materiaMap.has(materiaId)) {
+        materiaMap.set(materiaId, {
+          id: materiaId,
+          nome: materiaNome,
+          frenteMap: new Map(),
+          studentIds: new Set(),
+        });
+      }
+      const mat = materiaMap.get(materiaId)!;
+      mat.studentIds.add(usuario);
+
+      if (!mat.frenteMap.has(frenteId)) {
+        mat.frenteMap.set(frenteId, {
+          id: frenteId,
+          nome: frenteNome,
+          studentAvgs: [],
+          attempts: 0,
+        });
+      }
+      const fr = mat.frenteMap.get(frenteId)!;
+      fr.studentAvgs.push(row.avg);
+      fr.attempts += row.attempts;
+    }
+
+    const materias = Array.from(materiaMap.values()).map((mat) => {
+      const frentes = Array.from(mat.frenteMap.values()).map((fr) => ({
+        id: fr.id,
+        nome: fr.nome,
+        aproveitamento:
+          fr.studentAvgs.length > 0
+            ? fr.studentAvgs.reduce((a, b) => a + b, 0) / fr.studentAvgs.length
+            : 0,
+        studentsContributing: fr.studentAvgs.length,
+        attemptsContributing: fr.attempts,
+      }));
+
+      const totalWeight = frentes.reduce(
+        (s, f) => s + f.studentsContributing,
+        0,
+      );
+      const aproveitamento =
+        totalWeight > 0
+          ? frentes.reduce(
+              (s, f) => s + f.aproveitamento * f.studentsContributing,
+              0,
+            ) / totalWeight
+          : 0;
+
+      return {
+        id: mat.id,
+        nome: mat.nome,
+        aproveitamento,
+        studentsContributing: mat.studentIds.size,
+        attemptsContributing: frentes.reduce(
+          (s, f) => s + f.attemptsContributing,
+          0,
+        ),
+        frentes,
+      };
+    });
+
+    const geral =
+      materias.length > 0
+        ? materias.reduce((s, m) => s + m.aproveitamento, 0) / materias.length
+        : 0;
+
+    return {
+      geral,
+      totalAttempts: meta.totalAttempts,
+      totalAttemptsCompleted,
+      studentsWithAtLeastOneCompletedAttempt,
+      materias,
+    };
+  }
+}

--- a/src/modules/user-group-aggregates/user-group-aggregate.schema.ts
+++ b/src/modules/user-group-aggregates/user-group-aggregate.schema.ts
@@ -1,0 +1,122 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { ApiProperty } from '@nestjs/swagger';
+
+class FrenteAggregate {
+  @Prop()
+  @ApiProperty()
+  id: string;
+
+  @Prop()
+  @ApiProperty()
+  nome: string;
+
+  @Prop()
+  @ApiProperty()
+  aproveitamento: number;
+
+  @Prop()
+  @ApiProperty()
+  studentsContributing: number;
+
+  @Prop()
+  @ApiProperty()
+  attemptsContributing: number;
+}
+
+class MateriaAggregate {
+  @Prop()
+  @ApiProperty()
+  id: string;
+
+  @Prop()
+  @ApiProperty()
+  nome: string;
+
+  @Prop()
+  @ApiProperty()
+  aproveitamento: number;
+
+  @Prop()
+  @ApiProperty()
+  studentsContributing: number;
+
+  @Prop()
+  @ApiProperty()
+  attemptsContributing: number;
+
+  @Prop({ type: [FrenteAggregate] })
+  @ApiProperty({ type: [FrenteAggregate] })
+  frentes: FrenteAggregate[];
+}
+
+class AggregatePayload {
+  @Prop()
+  @ApiProperty()
+  geral: number;
+
+  @Prop()
+  @ApiProperty()
+  totalAttempts: number;
+
+  @Prop()
+  @ApiProperty()
+  totalAttemptsCompleted: number;
+
+  @Prop()
+  @ApiProperty()
+  studentsWithAtLeastOneCompletedAttempt: number;
+
+  @Prop({ type: [MateriaAggregate] })
+  @ApiProperty({ type: [MateriaAggregate] })
+  materias: MateriaAggregate[];
+}
+
+@Schema({
+  timestamps: true,
+  versionKey: false,
+  collection: 'user_group_aggregates',
+})
+export class UserGroupAggregate {
+  @Prop({ required: true, index: true })
+  @ApiProperty()
+  groupId: string;
+
+  @Prop({ required: true, enum: ['class'], default: 'class' })
+  @ApiProperty()
+  groupType: 'class';
+
+  @Prop({ required: true })
+  @ApiProperty()
+  month: string; // 'YYYY-MM'
+
+  @Prop({ required: true })
+  @ApiProperty()
+  monthStart: Date;
+
+  @Prop({ required: true })
+  @ApiProperty()
+  monthEnd: Date;
+
+  @Prop({ type: [String] })
+  @ApiProperty()
+  userIds: string[];
+
+  @Prop({ type: AggregatePayload })
+  @ApiProperty()
+  payload: AggregatePayload;
+
+  @Prop({ default: Date.now })
+  @ApiProperty()
+  generatedAt: Date;
+
+  @Prop()
+  @ApiProperty()
+  sourceHistoricoCount: number;
+}
+
+export const UserGroupAggregateSchema =
+  SchemaFactory.createForClass(UserGroupAggregate);
+UserGroupAggregateSchema.index(
+  { groupId: 1, groupType: 1, month: 1 },
+  { unique: true },
+);

--- a/src/modules/user-group-aggregates/user-group-aggregate.schema.ts
+++ b/src/modules/user-group-aggregates/user-group-aggregate.schema.ts
@@ -49,7 +49,7 @@ class MateriaAggregate {
   frentes: FrenteAggregate[];
 }
 
-class AggregatePayload {
+export class AggregatePayload {
   @Prop()
   @ApiProperty()
   geral: number;

--- a/src/modules/user-group-aggregates/user-group-aggregate.service.spec.ts
+++ b/src/modules/user-group-aggregates/user-group-aggregate.service.spec.ts
@@ -1,0 +1,126 @@
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { UserGroupAggregateService } from './user-group-aggregate.service';
+import { UserGroupAggregateRepository } from './user-group-aggregate.repository';
+import { CalculateAggregateDtoInput } from './dtos/calculate-aggregate.dto.input';
+import { AggregatePayload } from './user-group-aggregate.repository';
+
+const makeRepository = (): jest.Mocked<UserGroupAggregateRepository> =>
+  ({
+    listByGroup: jest.fn(),
+    findOneByMonth: jest.fn(),
+    aggregateMonth: jest.fn(),
+    upsert: jest.fn(),
+  }) as any;
+
+const makeAggregatePayload = (): AggregatePayload => ({
+  geral: 80,
+  totalAttempts: 5,
+  totalAttemptsCompleted: 3,
+  studentsWithAtLeastOneCompletedAttempt: 2,
+  materias: [],
+});
+
+describe('UserGroupAggregateService', () => {
+  let service: UserGroupAggregateService;
+  let repository: jest.Mocked<UserGroupAggregateRepository>;
+
+  beforeEach(() => {
+    repository = makeRepository();
+    service = new UserGroupAggregateService(repository);
+  });
+
+  describe('list', () => {
+    it('calls listByGroup with correct args and returns result', async () => {
+      const expected = [{ groupId: 'g1', groupType: 'class', month: '2026-04' }];
+      repository.listByGroup.mockResolvedValue(expected as any);
+
+      const result = await service.list('g1', 'class');
+
+      expect(repository.listByGroup).toHaveBeenCalledWith('g1', 'class');
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('findByMonth', () => {
+    it('returns the doc when found', async () => {
+      const doc = { groupId: 'g1', groupType: 'class', month: '2026-04' };
+      repository.findOneByMonth.mockResolvedValue(doc as any);
+
+      const result = await service.findByMonth('g1', 'class', '2026-04');
+
+      expect(repository.findOneByMonth).toHaveBeenCalledWith('g1', 'class', '2026-04');
+      expect(result).toBe(doc);
+    });
+
+    it('throws NotFoundException when doc not found', async () => {
+      repository.findOneByMonth.mockResolvedValue(null);
+
+      await expect(service.findByMonth('g1', 'class', '2026-04')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('calculate', () => {
+    const baseInput: CalculateAggregateDtoInput = {
+      groupId: 'g1',
+      groupType: 'class',
+      month: '2026-04',
+      monthStart: '2026-04-01T00:00:00.000Z',
+      monthEnd: '2026-04-30T23:59:59.999Z',
+      userIds: ['u1', 'u2'],
+    };
+
+    it('happy path — calls aggregateMonth then upsert and returns upserted doc', async () => {
+      const payload = makeAggregatePayload();
+      repository.aggregateMonth.mockResolvedValue({ payload });
+      const upserted = { groupId: 'g1', month: '2026-04', payload };
+      repository.upsert.mockResolvedValue(upserted as any);
+
+      const result = await service.calculate(baseInput);
+
+      expect(repository.aggregateMonth).toHaveBeenCalledWith({
+        userIds: baseInput.userIds,
+        monthStart: new Date(baseInput.monthStart),
+        monthEnd: new Date(baseInput.monthEnd),
+      });
+      expect(repository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          groupId: 'g1',
+          groupType: 'class',
+          month: '2026-04',
+          userIds: ['u1', 'u2'],
+          payload,
+          sourceHistoricoCount: payload.totalAttempts,
+        }),
+      );
+      expect(result).toBe(upserted);
+    });
+
+    it('empty userIds — does not throw BadRequestException', async () => {
+      const emptyPayload = makeAggregatePayload();
+      emptyPayload.totalAttempts = 0;
+      repository.aggregateMonth.mockResolvedValue({ payload: emptyPayload });
+      repository.upsert.mockResolvedValue({ groupId: 'g1' } as any);
+
+      const inputWithEmpty: CalculateAggregateDtoInput = {
+        ...baseInput,
+        userIds: [],
+      };
+
+      await expect(service.calculate(inputWithEmpty)).resolves.toBeDefined();
+      expect(repository.aggregateMonth).toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when monthStart is after monthEnd', async () => {
+      const badInput: CalculateAggregateDtoInput = {
+        ...baseInput,
+        monthStart: '2026-05-01T00:00:00.000Z',
+        monthEnd: '2026-04-01T00:00:00.000Z',
+      };
+
+      await expect(service.calculate(badInput)).rejects.toThrow(BadRequestException);
+      expect(repository.aggregateMonth).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/user-group-aggregates/user-group-aggregate.service.ts
+++ b/src/modules/user-group-aggregates/user-group-aggregate.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { UserGroupAggregateRepository } from './user-group-aggregate.repository';
+import { CalculateAggregateDtoInput } from './dtos/calculate-aggregate.dto.input';
+
+@Injectable()
+export class UserGroupAggregateService {
+  constructor(private readonly repository: UserGroupAggregateRepository) {}
+
+  list(groupId: string, groupType: 'class') {
+    return this.repository.listByGroup(groupId, groupType);
+  }
+
+  async findByMonth(groupId: string, groupType: 'class', month: string) {
+    const doc = await this.repository.findOneByMonth(groupId, groupType, month);
+    if (!doc) throw new NotFoundException('Snapshot not generated for this month');
+    return doc;
+  }
+
+  async calculate(input: CalculateAggregateDtoInput) {
+    const monthStart = new Date(input.monthStart);
+    const monthEnd = new Date(input.monthEnd);
+
+    if (monthStart > monthEnd) {
+      throw new BadRequestException('monthStart must be before monthEnd');
+    }
+
+    const aggregated = await this.repository.aggregateMonth({
+      userIds: input.userIds,
+      monthStart,
+      monthEnd,
+    });
+
+    return this.repository.upsert({
+      groupId: input.groupId,
+      groupType: input.groupType,
+      month: input.month,
+      monthStart,
+      monthEnd,
+      userIds: input.userIds,
+      payload: aggregated.payload as any,
+      generatedAt: new Date(),
+      sourceHistoricoCount: aggregated.payload.totalAttempts,
+    });
+  }
+}

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,9 +1,13 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "rootDir": "..",
   "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
+  "testRegex": "test/.+\\.e2e-spec\\.ts$",
+  "testTimeout": 30000,
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/src/$1"
   }
 }

--- a/test/user-group-aggregates.e2e-spec.ts
+++ b/test/user-group-aggregates.e2e-spec.ts
@@ -1,0 +1,199 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const request = require('supertest');
+import { AppModule } from '../src/app.module';
+import { UserGroupAggregate } from '../src/modules/user-group-aggregates/user-group-aggregate.schema';
+
+const GROUP_ID = 'e2e-test-group-' + Date.now();
+const GROUP_TYPE = 'class';
+const MONTH = '2026-05';
+const MONTH_START = '2026-05-01T00:00:00.000Z';
+const MONTH_END = '2026-05-31T23:59:59.999Z';
+const USER_IDS = ['user-e2e-1', 'user-e2e-2'];
+
+describe('UserGroupAggregates (e2e)', () => {
+  let app: INestApplication;
+  let aggModel: Model<UserGroupAggregate>;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.MONGODB = process.env.MONGODB ?? 'mongodb://localhost:27017/ms-simulado-test';
+    process.env.QUEUE_DRIVER = 'memory';
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: false,
+      }),
+    );
+    await app.init();
+
+    aggModel = moduleFixture.get<Model<UserGroupAggregate>>(
+      getModelToken(UserGroupAggregate.name),
+    );
+  });
+
+  afterAll(async () => {
+    // Clean up test documents created during the suite
+    await aggModel.deleteMany({ groupId: GROUP_ID });
+    await app.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 1: GET list with no docs → 200 empty array
+  // -------------------------------------------------------------------------
+  it('1. GET /v1/user-group-aggregates with no docs returns 200 and empty array', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/v1/user-group-aggregates')
+      .query({ groupId: GROUP_ID, groupType: GROUP_TYPE });
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 2: GET by-month with no doc → 404
+  // -------------------------------------------------------------------------
+  it('2. GET /v1/user-group-aggregates/by-month with no doc returns 404', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/v1/user-group-aggregates/by-month')
+      .query({ groupId: GROUP_ID, groupType: GROUP_TYPE, month: MONTH });
+
+    expect(res.status).toBe(404);
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 3: POST calculate with empty userIds → 400
+  // -------------------------------------------------------------------------
+  it('3. POST /v1/user-group-aggregates/calculate with empty userIds returns 400', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/v1/user-group-aggregates/calculate')
+      .send({
+        groupId: GROUP_ID,
+        groupType: GROUP_TYPE,
+        month: MONTH,
+        monthStart: MONTH_START,
+        monthEnd: MONTH_END,
+        userIds: [],
+      });
+
+    expect(res.status).toBe(400);
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 4: POST calculate with valid input but no historicos → 200 zeroed
+  // -------------------------------------------------------------------------
+  it('4. POST /v1/user-group-aggregates/calculate with valid input and 0 historicos returns zeroed payload', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/v1/user-group-aggregates/calculate')
+      .send({
+        groupId: GROUP_ID,
+        groupType: GROUP_TYPE,
+        month: MONTH,
+        monthStart: MONTH_START,
+        monthEnd: MONTH_END,
+        userIds: USER_IDS,
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      groupId: GROUP_ID,
+      groupType: GROUP_TYPE,
+      month: MONTH,
+    });
+    expect(res.body.payload).toMatchObject({
+      geral: 0,
+      totalAttempts: 0,
+      totalAttemptsCompleted: 0,
+      studentsWithAtLeastOneCompletedAttempt: 0,
+      materias: [],
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 5: POST calculate called twice → upsert, no error, generatedAt updates
+  // -------------------------------------------------------------------------
+  it('5. POST /v1/user-group-aggregates/calculate called twice upserts without error', async () => {
+    const payload = {
+      groupId: GROUP_ID,
+      groupType: GROUP_TYPE,
+      month: MONTH,
+      monthStart: MONTH_START,
+      monthEnd: MONTH_END,
+      userIds: USER_IDS,
+    };
+
+    const res1 = await request(app.getHttpServer())
+      .post('/v1/user-group-aggregates/calculate')
+      .send(payload);
+    expect(res1.status).toBe(201);
+
+    // Small delay so generatedAt can differ
+    await new Promise((r) => setTimeout(r, 10));
+
+    const res2 = await request(app.getHttpServer())
+      .post('/v1/user-group-aggregates/calculate')
+      .send(payload);
+    expect(res2.status).toBe(201);
+
+    // Both responses share the same groupId/groupType/month (upsert, not duplicate)
+    expect(res1.body.groupId).toBe(res2.body.groupId);
+    expect(res1.body.groupType).toBe(res2.body.groupType);
+    expect(res1.body.month).toBe(res2.body.month);
+
+    // Verify only one document exists in the DB
+    const count = await aggModel.countDocuments({
+      groupId: GROUP_ID,
+      groupType: GROUP_TYPE,
+      month: MONTH,
+    });
+    expect(count).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 6: GET list after calculate → 200, array with 1 item
+  // -------------------------------------------------------------------------
+  it('6. GET /v1/user-group-aggregates after calculate returns 200 with 1 item', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/v1/user-group-aggregates')
+      .query({ groupId: GROUP_ID, groupType: GROUP_TYPE });
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toMatchObject({
+      groupId: GROUP_ID,
+      groupType: GROUP_TYPE,
+      month: MONTH,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 7: GET by-month after calculate → 200, full doc
+  // -------------------------------------------------------------------------
+  it('7. GET /v1/user-group-aggregates/by-month after calculate returns 200 with full doc', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/v1/user-group-aggregates/by-month')
+      .query({ groupId: GROUP_ID, groupType: GROUP_TYPE, month: MONTH });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      groupId: GROUP_ID,
+      groupType: GROUP_TYPE,
+      month: MONTH,
+    });
+    expect(res.body.payload).toBeDefined();
+    expect(typeof res.body.payload.geral).toBe('number');
+    expect(Array.isArray(res.body.payload.materias)).toBe(true);
+  });
+});

--- a/test/user-group-aggregates.e2e-spec.ts
+++ b/test/user-group-aggregates.e2e-spec.ts
@@ -1,3 +1,5 @@
+// Requires a real MongoDB instance (process.env.MONGODB or mongodb://localhost:27017/ms-simulado-test).
+// In CI, ensure a MongoDB service is running (e.g., via docker-compose or GitHub Actions service).
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getModelToken } from '@nestjs/mongoose';


### PR DESCRIPTION
## Summary

- Adds `user-group-aggregates` module: MongoDB schema with compound unique index `(groupId, groupType, month)`
- MongoDB aggregation pipeline on `Historicos` collection — filters completed attempts (`$size(respostas) == questoesRespondidas`), groups by student × matéria × frente, computes weighted `aproveitamento` per matéria and overall `geral`
- Three endpoints: `POST /v1/user-group-aggregates/calculate`, `GET /v1/user-group-aggregates`, `GET /v1/user-group-aggregates/by-month`
- Unit tests (6) + E2E tests (7) covering happy path, empty userIds, date validation, upsert idempotency and 404

## Context

This is **Fase A** of the turma-analytics-simulado feature. It provides the calculation engine that `api-vcnafacul` will call (Fase B) when a coordinator requests a refresh or when the weekly/monthly cron fires (Fase D). No other service calls this yet.

## Test Plan

- [ ] `npx jest --detectOpenHandles --forceExit src/modules/user-group-aggregates/` — 6 unit tests pass
- [ ] `npx jest --detectOpenHandles --forceExit test/user-group-aggregates.e2e-spec.ts` — 7 E2E tests pass (requires MongoDB)
- [ ] `npm run build` — compiles without errors
- [ ] Pre-existing failure in `historico.controller.spec.ts` is unrelated (tries to bootstrap AppModule in unit test without MongoDB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)