### PR TITLE
fix(user-group-aggregates): dedupe materias/frentes by ObjectId string key

### DIFF
--- a/src/modules/user-group-aggregates/user-group-aggregate.repository.spec.ts
+++ b/src/modules/user-group-aggregates/user-group-aggregate.repository.spec.ts
@@ -1,0 +1,118 @@
+import { Types } from 'mongoose';
+import { UserGroupAggregateRepository } from './user-group-aggregate.repository';
+
+describe('UserGroupAggregateRepository.buildPayload', () => {
+  const repo = new UserGroupAggregateRepository({} as any, {} as any);
+
+  function call(rows: any[], totalAttempts = rows.length) {
+    return (repo as any).buildPayload(
+      {
+        completedRows: rows,
+        completedCount: [{ total: rows.length }],
+        completedUsers: [{ total: new Set(rows.map((r) => String(r._id.usuario))).size }],
+      },
+      { totalAttempts },
+    );
+  }
+
+  it('deduplica matéria/frente quando os ids vêm como ObjectId do Mongo', () => {
+    // Reproduz o bug: 1 matéria "Matemática" com 3 frentes do mesmo aluno.
+    // Antes da correção: cada frente virava uma matéria separada por causa
+    // da comparação de ObjectId por referência no Map.
+    const materiaId = new Types.ObjectId();
+    const usuario = new Types.ObjectId();
+    const rows = [
+      {
+        _id: {
+          usuario,
+          materiaId,
+          materiaNome: 'Matemática',
+          frenteId: new Types.ObjectId(),
+          frenteNome: 'Aritmética',
+        },
+        avg: 0.8,
+        attempts: 1,
+      },
+      {
+        _id: {
+          usuario,
+          materiaId,
+          materiaNome: 'Matemática',
+          frenteId: new Types.ObjectId(),
+          frenteNome: 'Álgebra',
+        },
+        avg: 0.5,
+        attempts: 1,
+      },
+      {
+        _id: {
+          usuario,
+          materiaId,
+          materiaNome: 'Matemática',
+          frenteId: new Types.ObjectId(),
+          frenteNome: 'Geometria',
+        },
+        avg: 0.2,
+        attempts: 1,
+      },
+    ];
+
+    const payload = call(rows);
+
+    expect(payload.materias).toHaveLength(1);
+    const mat = payload.materias[0];
+    expect(mat.nome).toBe('Matemática');
+    expect(mat.id).toBe(String(materiaId));
+    expect(mat.frentes).toHaveLength(3);
+    expect(mat.studentsContributing).toBe(1);
+    expect(mat.attemptsContributing).toBe(3);
+  });
+
+  it('dedupe persiste mesmo quando o mesmo aluno aparece em linhas diferentes', () => {
+    const materiaA = new Types.ObjectId();
+    const materiaB = new Types.ObjectId();
+    const u1 = new Types.ObjectId();
+    const u2 = new Types.ObjectId();
+    const rows = [
+      {
+        _id: {
+          usuario: u1,
+          materiaId: materiaA,
+          materiaNome: 'Matemática',
+          frenteId: new Types.ObjectId(),
+          frenteNome: 'Aritmética',
+        },
+        avg: 0.9,
+        attempts: 1,
+      },
+      {
+        _id: {
+          usuario: u2,
+          materiaId: materiaA,
+          materiaNome: 'Matemática',
+          frenteId: new Types.ObjectId(),
+          frenteNome: 'Aritmética',
+        },
+        avg: 0.7,
+        attempts: 1,
+      },
+      {
+        _id: {
+          usuario: u1,
+          materiaId: materiaB,
+          materiaNome: 'Português',
+          frenteId: new Types.ObjectId(),
+          frenteNome: 'Gramática',
+        },
+        avg: 0.6,
+        attempts: 1,
+      },
+    ];
+
+    const payload = call(rows);
+
+    expect(payload.materias).toHaveLength(2);
+    const mat = payload.materias.find((m: any) => m.nome === 'Matemática')!;
+    expect(mat.studentsContributing).toBe(2);
+  });
+});

--- a/src/modules/user-group-aggregates/user-group-aggregate.repository.ts
+++ b/src/modules/user-group-aggregates/user-group-aggregate.repository.ts
@@ -141,27 +141,31 @@ export class UserGroupAggregateRepository {
 
     for (const row of completedRows) {
       const { materiaId, materiaNome, frenteId, frenteNome, usuario } = row._id;
+      // IDs vêm como ObjectId do Mongo; Map.has compara por referência,
+      // então sem .toString() cada linha vira uma matéria/frente "nova".
+      const materiaKey = String(materiaId);
+      const frenteKey = String(frenteId);
 
-      if (!materiaMap.has(materiaId)) {
-        materiaMap.set(materiaId, {
-          id: materiaId,
+      if (!materiaMap.has(materiaKey)) {
+        materiaMap.set(materiaKey, {
+          id: materiaKey,
           nome: materiaNome,
           frenteMap: new Map(),
           studentIds: new Set(),
         });
       }
-      const mat = materiaMap.get(materiaId)!;
-      mat.studentIds.add(usuario);
+      const mat = materiaMap.get(materiaKey)!;
+      mat.studentIds.add(String(usuario));
 
-      if (!mat.frenteMap.has(frenteId)) {
-        mat.frenteMap.set(frenteId, {
-          id: frenteId,
+      if (!mat.frenteMap.has(frenteKey)) {
+        mat.frenteMap.set(frenteKey, {
+          id: frenteKey,
           nome: frenteNome,
           studentAvgs: [],
           attempts: 0,
         });
       }
-      const fr = mat.frenteMap.get(frenteId)!;
+      const fr = mat.frenteMap.get(frenteKey)!;
       fr.studentAvgs.push(row.avg);
       fr.attempts += row.attempts;
     }


### PR DESCRIPTION
## Summary
- Bug: agregados por turma duplicavam matérias/frentes (ex: 1 matéria \"Matemática\" com 3 frentes virava 3 entradas \"Matemática\" no payload, observado em homol).
- Causa raiz: `Map.has/set` compara `ObjectId` por referência, então cada linha do `$group` da pipeline criava uma entrada nova mesmo quando o id era igual.
- Correção: coage `materiaId` e `frenteId` para `String(...)` antes de usar como chave de `Map` em `buildPayload`.

## Test Plan
- [x] `npx jest src/modules/user-group-aggregates/user-group-aggregate.repository.spec.ts` — 2 passing
- Regressões cobertas:
  - 1 aluno, 1 matéria com 3 frentes diferentes → 1 matéria, 3 frentes, `studentsContributing=1`, `attemptsContributing=3`
  - 2 alunos em 2 matérias distintas → 2 matérias, `studentsContributing=2` na compartilhada

🤖 Generated with [Claude Code](https://claude.com/claude-code)