### PR TITLE
feat(questao): número da questão opcional (nullable)

### DIFF
--- a/src/modules/questao/dtos/create.dto.input.ts
+++ b/src/modules/questao/dtos/create.dto.input.ts
@@ -36,9 +36,10 @@ export class CreateQuestaoDTOInput {
   @MateriaExist({ message: 'materia não existe' })
   public materia: string;
 
-  @ApiProperty()
+  @ApiProperty({ required: false, nullable: true })
+  @IsOptional()
   @IsNumber()
-  public numero: number;
+  public numero?: number | null;
 
   @ApiProperty({ required: false })
   @IsOptional()

--- a/src/modules/questao/dtos/update-classificacao.dto.input.ts
+++ b/src/modules/questao/dtos/update-classificacao.dto.input.ts
@@ -18,9 +18,10 @@ export class UpdateClassificacaoDTOInput {
   @ProvaExist({ message: 'prova não existe' })
   public prova: string;
 
-  @ApiProperty()
+  @ApiProperty({ required: false, nullable: true })
+  @IsOptional()
   @IsNumber()
-  public numero: number;
+  public numero?: number | null;
 
   @ApiProperty({ enum: EnemArea })
   @IsEnum(EnemArea)

--- a/src/modules/questao/questao.schema.ts
+++ b/src/modules/questao/questao.schema.ts
@@ -31,9 +31,9 @@ export class Questao extends QuestaoReview {
   @ApiProperty()
   public materia: Materia;
 
-  @Prop()
-  @ApiProperty()
-  public numero: number;
+  @Prop({ required: false, default: null })
+  @ApiProperty({ required: false, nullable: true })
+  public numero: number | null;
 
   @Prop({ required: false, default: '' })
   @ApiProperty()

--- a/src/modules/questao/questao.service.spec.ts
+++ b/src/modules/questao/questao.service.spec.ts
@@ -1,0 +1,92 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { CreateQuestaoDTOInput } from './dtos/create.dto.input';
+import { Alternativa } from './enums/alternativa.enum';
+import { EnemArea } from './enums/enem-area.enum';
+import { QuestaoService } from './questao.service';
+
+const mockFactory = {
+  verifyNumberProva: jest.fn(),
+  createQuestion: jest.fn(),
+};
+
+const mockProvaFactory = {
+  getFactory: jest.fn().mockReturnValue(mockFactory),
+};
+
+const mockProvaRepository = {
+  getById: jest.fn().mockResolvedValue({ _id: 'prova-id', exame: {}, ano: 2023 }),
+};
+
+function makeService(): QuestaoService {
+  return new QuestaoService(
+    null as any,
+    null as any,
+    mockProvaRepository as any,
+    null as any,
+    null as any,
+    null as any,
+    null as any,
+    null as any,
+    mockProvaFactory as any,
+  );
+}
+
+function makeCreateDto(numero: number | null | undefined): CreateQuestaoDTOInput {
+  return {
+    prova: 'prova-id',
+    enemArea: EnemArea.Linguagens,
+    numero: numero as any,
+    alternativa: Alternativa.A,
+  } as CreateQuestaoDTOInput;
+}
+
+describe('QuestaoService.create', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockProvaRepository.getById.mockResolvedValue({
+      _id: 'prova-id',
+      exame: {},
+      ano: 2023,
+    });
+    mockProvaFactory.getFactory.mockReturnValue(mockFactory);
+    mockFactory.createQuestion.mockResolvedValue({ _id: 'new-question-id' });
+  });
+
+  it('skips conflict check and creates question when numero is null', async () => {
+    const service = makeService();
+    await service.create(makeCreateDto(null));
+
+    expect(mockFactory.verifyNumberProva).not.toHaveBeenCalled();
+    expect(mockFactory.createQuestion).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips conflict check and creates question when numero is undefined', async () => {
+    const service = makeService();
+    await service.create(makeCreateDto(undefined));
+
+    expect(mockFactory.verifyNumberProva).not.toHaveBeenCalled();
+    expect(mockFactory.createQuestion).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks conflict and creates when numero is valid and slot is free', async () => {
+    mockFactory.verifyNumberProva.mockResolvedValue(true);
+    const service = makeService();
+    await service.create(makeCreateDto(42));
+
+    expect(mockFactory.verifyNumberProva).toHaveBeenCalledWith('prova-id', 42);
+    expect(mockFactory.createQuestion).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws CONFLICT when numero is taken', async () => {
+    mockFactory.verifyNumberProva.mockResolvedValue(false);
+    const service = makeService();
+
+    await expect(service.create(makeCreateDto(42))).rejects.toThrow(
+      new HttpException(
+        'Possível questão já cadastrada com número 42.',
+        HttpStatus.CONFLICT,
+      ),
+    );
+    expect(mockFactory.createQuestion).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/questao/questao.service.ts
+++ b/src/modules/questao/questao.service.ts
@@ -50,7 +50,7 @@ export class QuestaoService {
   public async create(item: CreateQuestaoDTOInput): Promise<Questao> {
     const prova = await this.provaRepository.getById(item.prova);
     const factory = this.provaFactory.getFactory(prova.exame, prova.ano);
-    if (await factory.verifyNumberProva(prova._id, item.numero)) {
+    if (item.numero == null || await factory.verifyNumberProva(prova._id, item.numero)) {
       return await factory.createQuestion(item);
     }
     throw new HttpException(


### PR DESCRIPTION
## Summary
- Campo `numero` da questão passa a ser opcional (nullable) no schema, DTOs de criação e atualização de classificação
- A verificação de conflito de número (`verifyNumberProva`) é pulada quando `numero` é null/undefined, permitindo salvar a questão sem número
- Adicionados testes unitários para `QuestaoService.create` cobrindo os cenários null, undefined, slot livre e slot ocupado

## Motivation
Ao precisar trocar o número de uma questão, o usuário era forçado a um fluxo de 4 operações (abrir outra questão → trocar o número → salvar → voltar e atribuir o número desejado). Com numero nullable, basta clicar em "Remover número" na outra questão e liberar o slot em uma operação.

## Test Plan
- [ ] `npx jest --detectOpenHandles --forceExit src/modules/questao/questao.service.spec.ts` — 4 testes passando
- [ ] Criar questão sem número via API (`numero: null`) — deve aceitar sem conflito
- [ ] Criar questão com número já ocupado — deve retornar 409 CONFLICT
- [ ] Atualizar classificação com `numero: null` — deve aceitar