### PR TITLE
fix(ms-simulado): incluir createdAt no getAll de prova

### DIFF
--- a/src/modules/prova/dtos/get-all.dto.output.ts
+++ b/src/modules/prova/dtos/get-all.dto.output.ts
@@ -37,4 +37,7 @@ export class GetProvaDTOOutout {
 
   @ApiProperty()
   enemAreas: string[];
+
+  @ApiProperty()
+  createdAt: Date;
 }

--- a/src/modules/prova/prova.service.ts
+++ b/src/modules/prova/prova.service.ts
@@ -62,6 +62,7 @@ export class ProvaService {
         filename: result.filename,
         gabarito: result.gabarito,
         enemAreas: result.enemAreas,
+        createdAt: result.createdAt,
       } as GetProvaDTOOutout;
     } catch (error: any) {
       throw new HttpException(error.message, HttpStatus.CONFLICT);
@@ -505,6 +506,7 @@ export class ProvaService {
       filename: prova.filename,
       gabarito: prova.gabarito,
       enemAreas: prova.enemAreas,
+      createdAt: prova.createdAt,
     } as GetProvaDTOOutout;
   }
 }

--- a/src/modules/prova/prova.service.ts
+++ b/src/modules/prova/prova.service.ts
@@ -94,6 +94,7 @@ export class ProvaService {
           filename: prova.filename,
           enemAreas: prova.enemAreas,
           totalQuestaoCadastradas: prova.questoes.length,
+          createdAt: prova.createdAt,
         };
       }),
     };


### PR DESCRIPTION
## Summary

- `ProvaService.getAll` mapeava os campos manualmente mas omitia `createdAt`, fazendo o campo "Cadastrado em" aparecer vazio na tela de provas
- `GetProvaDTOOutout` agora declara o campo `createdAt: Date`
- O mapeamento no `getAll` agora inclui `createdAt: prova.createdAt`

## Test plan

- [ ] Abrir a tela de Provas — cards devem exibir a data de cadastro em "Cadastrado em"
- [ ] Verificar que o build passa: `yarn build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)