### PR TITLE
fix(historico): corrigir persistência de times em calcularMediaAproveitamento

### DIFF
--- a/src/modules/historico/historico.service.spec.ts
+++ b/src/modules/historico/historico.service.spec.ts
@@ -1,0 +1,71 @@
+import { HistoricoService } from './historico.service';
+import { AproveitamentoHistorico } from './types/aproveitamento';
+
+function makeAproveitamento(
+  materiaAprov: number,
+  frenteAprov: number,
+): AproveitamentoHistorico {
+  return {
+    geral: materiaAprov,
+    materias: [
+      {
+        id: 'mat-1',
+        nome: 'Matemática',
+        aproveitamento: materiaAprov,
+        frentes: [
+          {
+            id: 'frt-1',
+            nome: 'Álgebra',
+            aproveitamento: frenteAprov,
+            materia: 'Matemática',
+          },
+        ],
+      },
+    ],
+  } as unknown as AproveitamentoHistorico;
+}
+
+function makeHistorico(aproveitamento: AproveitamentoHistorico) {
+  return {
+    _id: 'hist-id',
+    simulado: {
+      nome: 'Simulado',
+      questoes: [] as any[],
+      aproveitamento: 0,
+      vezesRespondido: 0,
+    },
+    aproveitamento,
+    tempoRealizado: 60,
+    questoesRespondidas: 10,
+    createdAt: new Date(),
+  };
+}
+
+const mockRepository = {
+  getToPerformance: jest.fn(),
+};
+
+function makeService(): HistoricoService {
+  return new HistoricoService(mockRepository as any);
+}
+
+describe('HistoricoService.calcularMediaAproveitamento', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calcula média correta para 3 históricos na mesma matéria com aproveitamentos distintos', async () => {
+    // sem o fix: 3º histórico usa times=1 do Map (não atualizado), dando 0.825 errado
+    mockRepository.getToPerformance.mockResolvedValue([
+      makeHistorico(makeAproveitamento(0.5, 0.5)),
+      makeHistorico(makeAproveitamento(0.8, 0.8)),
+      makeHistorico(makeAproveitamento(1.0, 1.0)),
+    ]);
+
+    const result = await makeService().getPerformance('user-1');
+
+    const expected = (0.5 + 0.8 + 1.0) / 3; // ≈ 0.7667
+    expect(result.performanceMateriaFrente.materias[0].aproveitamento).toBeCloseTo(expected, 5);
+    expect(result.performanceMateriaFrente.frentes[0].aproveitamento).toBeCloseTo(expected, 5);
+  });
+});

--- a/src/modules/historico/historico.service.ts
+++ b/src/modules/historico/historico.service.ts
@@ -76,6 +76,7 @@ export class HistoricoService {
             (times * materiaExistente.aproveitamento + materia.aproveitamento) /
             (times + 1);
           times = times + 1;
+          materiaTimesMap.set(materia.nome, times);
         }
 
         // Atualiza ou adiciona a média das frentes no frentesMap
@@ -85,10 +86,12 @@ export class HistoricoService {
             frenteTimesMap.set(frente.nome, 1);
           } else {
             const frenteExistente = frentesMap.get(frente.nome)!;
-            const times = frenteTimesMap.get(frente.nome)!;
+            let times = frenteTimesMap.get(frente.nome)!;
             frenteExistente.aproveitamento =
               (times * frenteExistente.aproveitamento + frente.aproveitamento) /
               (times + 1);
+            times = times + 1;
+            frenteTimesMap.set(frente.nome, times);
           }
         });
       });


### PR DESCRIPTION
## Summary

- `materiaTimesMap` não era atualizado após incremento do contador `times` — o 3º histórico em diante usava `times=1` ao invés do valor acumulado real
- `frenteTimesMap` tinha o mesmo bug, agravado por `const times` que nem permitia incremento local
- Ambos os Maps agora recebem `.set()` após cada atualização de média

## Test Plan

- [x] Teste de regressão `historico.service.spec.ts`: 3 históricos com `[0.5, 0.8, 1.0]` na mesma matéria/frente → espera `(0.5+0.8+1.0)/3 ≈ 0.7667` (sem o fix recebia `0.825`)
- [x] Suite completa verde: 18 testes, 7 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)