### PR TITLE
feat(categoria): Card 01 — bloquear delete de categoria em uso + filtro soft-deleted

### DIFF
--- a/src/modules/categoria/categoria.module.ts
+++ b/src/modules/categoria/categoria.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { CategoriaService } from './categoria.service';
 import { CategoriaController } from './categoria.controller';
 import { CategoriaRepository } from './categoria.repository';
@@ -11,9 +11,11 @@ import { FrenteModule } from '../frente/frente.module';
 import { MateriaModule } from '../materia/materia.module';
 import { ExameModule } from '../exame/exame.module';
 import { ExameExistValidator } from '../exame/validator/exame-exist.validator';
+import { SimuladoModule } from '../simulado/simulado.module';
 
 @Module({
   imports: [
+    forwardRef(() => SimuladoModule),
     MongooseModule.forFeature([
       { name: Categoria.name, schema: CategoriaSchema },
     ]),

--- a/src/modules/categoria/categoria.repository.spec.ts
+++ b/src/modules/categoria/categoria.repository.spec.ts
@@ -1,0 +1,29 @@
+import { CategoriaRepository } from './categoria.repository';
+
+describe('CategoriaRepository.getAll', () => {
+  it('exclui soft-deleted (deleted: { $ne: true }) preservando where e populate', async () => {
+    const populate = jest.fn().mockResolvedValue([{ nome: 'Enem Dia 1' }]);
+    const chainWhere = jest.fn().mockReturnValue({ populate });
+    const limit = jest.fn().mockReturnValue({ where: chainWhere });
+    const skip = jest.fn().mockReturnValue({ limit });
+    const find = jest.fn().mockReturnValue({ skip });
+
+    const countDocuments = jest.fn().mockResolvedValue(1);
+    const modelWhere = jest.fn().mockReturnValue({ countDocuments });
+
+    const model = { find, where: modelWhere } as any;
+    const repo = new CategoriaRepository(model);
+
+    const result = await repo.getAll({ page: 1, limit: 10, where: { custom: true } } as any);
+
+    expect(chainWhere).toHaveBeenCalledWith({ deleted: { $ne: true }, custom: true });
+    expect(modelWhere).toHaveBeenCalledWith({ deleted: { $ne: true }, custom: true });
+    expect(populate).toHaveBeenCalledWith('exame');
+    expect(result).toEqual({
+      data: [{ nome: 'Enem Dia 1' }],
+      page: 1,
+      limit: 10,
+      totalItems: 1,
+    });
+  });
+});

--- a/src/modules/categoria/categoria.repository.ts
+++ b/src/modules/categoria/categoria.repository.ts
@@ -21,13 +21,15 @@ export class CategoriaRepository extends BaseRepository<Categoria> {
     limit,
     where,
   }: GetAllWhereInput): Promise<GetAllOutput<Categoria>> {
+    // guard por último: caller não pode sobrescrever o filtro de soft-delete
+    const filter = { ...where, deleted: { $ne: true } };
     const data = await this.model
       .find()
       .skip((page - 1) * limit)
       .limit(limit ?? Infinity)
-      .where({ ...where })
+      .where(filter)
       .populate('exame');
-    const totalItems = await this.model.where({ ...where }).countDocuments();
+    const totalItems = await this.model.where(filter).countDocuments();
     return { data, page, limit, totalItems };
   }
 }

--- a/src/modules/categoria/categoria.service.spec.ts
+++ b/src/modules/categoria/categoria.service.spec.ts
@@ -1,0 +1,68 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { CategoriaService } from './categoria.service';
+
+function makeService(overrides?: {
+  getById?: jest.Mock;
+  deleteFn?: jest.Mock;
+  countByCategoria?: jest.Mock;
+}) {
+  const repository = {
+    getById: overrides?.getById ?? jest.fn().mockResolvedValue({ _id: 'cat-1' }),
+    delete: overrides?.deleteFn ?? jest.fn().mockResolvedValue(undefined),
+  };
+  const simuladoRepository = {
+    countByCategoria: overrides?.countByCategoria ?? jest.fn().mockResolvedValue(0),
+  };
+  const service = new CategoriaService(
+    repository as any,
+    simuladoRepository as any,
+  );
+  return { service, repository, simuladoRepository };
+}
+
+describe('CategoriaService.delete', () => {
+  it('deleta quando nenhum simulado usa a categoria', async () => {
+    const { service, repository, simuladoRepository } = makeService();
+
+    await service.delete('cat-1');
+
+    expect(simuladoRepository.countByCategoria).toHaveBeenCalledWith('cat-1');
+    expect(repository.delete).toHaveBeenCalledWith('cat-1');
+  });
+
+  it('lança 409 com o contador quando a categoria está em uso', async () => {
+    const { service, repository } = makeService({
+      countByCategoria: jest.fn().mockResolvedValue(3),
+    });
+
+    await expect(service.delete('cat-1')).rejects.toBeInstanceOf(
+      ConflictException,
+    );
+    expect(repository.delete).not.toHaveBeenCalled();
+  });
+
+  it('inclui simuladosUsando no payload do 409', async () => {
+    const { service } = makeService({
+      countByCategoria: jest.fn().mockResolvedValue(2),
+    });
+
+    const error = await service.delete('cat-1').catch((e) => e);
+
+    expect(error).toBeInstanceOf(ConflictException);
+    expect((error as ConflictException).getResponse()).toEqual({
+      message: 'Categoria em uso e não pode ser excluída',
+      simuladosUsando: 2,
+    });
+  });
+
+  it('lança 404 quando a categoria não existe', async () => {
+    const { service, simuladoRepository } = makeService({
+      getById: jest.fn().mockResolvedValue(null),
+    });
+
+    await expect(service.delete('cat-x')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+    expect(simuladoRepository.countByCategoria).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/categoria/categoria.service.ts
+++ b/src/modules/categoria/categoria.service.ts
@@ -1,13 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  Inject,
+  Injectable,
+  NotFoundException,
+  forwardRef,
+} from '@nestjs/common';
 import { GetAllInput } from 'src/shared/base/interfaces/get-all.input';
 import { GetAllOutput } from 'src/shared/base/interfaces/get-all.output';
+import { SimuladoRepository } from '../simulado/simulado.repository';
 import { CreateCategoriaDTOInput } from './dtos/create.dto.input';
 import { Categoria } from './schemas/categoria.schema';
 import { CategoriaRepository } from './categoria.repository';
 
 @Injectable()
 export class CategoriaService {
-  constructor(private readonly repository: CategoriaRepository) {}
+  constructor(
+    private readonly repository: CategoriaRepository,
+    @Inject(forwardRef(() => SimuladoRepository))
+    private readonly simuladoRepository: SimuladoRepository,
+  ) {}
 
   public async add(item: CreateCategoriaDTOInput): Promise<Categoria> {
     const categoria = Object.assign(new Categoria(), item);
@@ -23,6 +34,19 @@ export class CategoriaService {
   }
 
   public async delete(id: string): Promise<void> {
+    const categoria = await this.repository.getById(id);
+    if (!categoria) {
+      throw new NotFoundException(`Categoria ${id} não encontrada`);
+    }
+
+    const simuladosUsando = await this.simuladoRepository.countByCategoria(id);
+    if (simuladosUsando > 0) {
+      throw new ConflictException({
+        message: 'Categoria em uso e não pode ser excluída',
+        simuladosUsando,
+      });
+    }
+
     await this.repository.delete(id);
   }
 }

--- a/src/modules/simulado/simulado.module.ts
+++ b/src/modules/simulado/simulado.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { QueueModule } from 'src/shared/modules/queue/queue.module';
 import { ExameModule } from '../exame/exame.module';
@@ -23,7 +23,7 @@ import { SimuladoService } from './simulado.service';
     ]),
     QueueModule,
     QuestaoModule,
-    CategoriaModule,
+    forwardRef(() => CategoriaModule),
     ExameModule,
     FrenteModule,
     MateriaModule,

--- a/src/modules/simulado/simulado.repository.spec.ts
+++ b/src/modules/simulado/simulado.repository.spec.ts
@@ -1,0 +1,16 @@
+import { SimuladoRepository } from './simulado.repository';
+
+describe('SimuladoRepository.countByCategoria', () => {
+  it('conta simulados não-deletados que referenciam a categoria', async () => {
+    const countDocuments = jest.fn().mockResolvedValue(3);
+    const repo = new SimuladoRepository({ countDocuments } as any);
+
+    const total = await repo.countByCategoria('cat-123');
+
+    expect(total).toBe(3);
+    expect(countDocuments).toHaveBeenCalledWith({
+      categoria: 'cat-123',
+      deleted: { $ne: true },
+    });
+  });
+});

--- a/src/modules/simulado/simulado.repository.ts
+++ b/src/modules/simulado/simulado.repository.ts
@@ -12,6 +12,13 @@ export class SimuladoRepository extends BaseRepository<Simulado> {
     super(model);
   }
 
+  async countByCategoria(categoriaId: string): Promise<number> {
+    return this.model.countDocuments({
+      categoria: categoriaId,
+      deleted: { $ne: true },
+    });
+  }
+
   async getById(id: string): Promise<Simulado | null> {
     return await this.model
       .findById(id)


### PR DESCRIPTION
Closes #153

Etapa 3 (CRUD Categoria) — Card 01. Enriquece o backend do `ms-simulado` para o CRUD de categorias.

## Summary
- **`SimuladoRepository.countByCategoria(categoriaId)`** — conta simulados não-deletados que referenciam a categoria (filtro pelo campo booleano `deleted`, correto — não `deletedAt`).
- **`CategoriaService.delete`** — 404 se a categoria não existe; **409** com payload `{ message, simuladosUsando }` se algum simulado a referencia; só então soft-delete. Efeito: as 6 categorias seedadas ficam naturalmente protegidas (todas têm simulados em uso).
- **`CategoriaRepository.getAll`** — passa a filtrar soft-deleted (`deleted: { $ne: true }`), **preservando** o `where` do caller e o `.populate('exame')`. Guard posto por último no spread (`{ ...where, deleted: { $ne: true } }`) para o caller não conseguir sobrescrevê-lo.
- **Ciclo `CategoriaModule ↔ SimuladoModule`** resolvido com `forwardRef` nos dois lados (risco #1 do card).

## Decisões
- **CRUD imutável**: nenhuma rota `PATCH`/update de categoria foi adicionada (confirmado no controller).
- `getById` inalterado: continua retornando mesmo categorias soft-deleted (compat com simulados históricos).
- Mantido `@Inject(forwardRef(() => SimuladoRepository))` no `CategoriaService` como escolha defensiva. A app foi confirmada bootando (`Nest application successfully started`), então o ciclo resolve; o forwardRef no parâmetro é belt-and-suspenders e não causa dano.

## Test Plan
- [x] Unit: `countByCategoria` (filtro), `delete` (sucesso, 409 c/ contador, payload, 404), `getAll` (filtro + where + populate) — **6/6 passam**
- [x] `npm run build` limpo
- [x] Boot local: `Nest application successfully started` (ciclo de DI resolve)
- [ ] Homol: excluir "Enem Dia 1" retorna 409; `GET /v1/categoria` não lista soft-deleted

## Fora de escopo (registrado)
`SimuladoRepository.getTotalEntity()`/`entityActived()` filtram por `{ deletedAt: null }` (campo inexistente no schema — bug pré-existente na `develop`). Não corrigido aqui para não ampliar escopo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)