### PR TITLE
fix(build): restaura dist/main.js excluindo scripts/ do nest build

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "scripts", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Contexto

Em homol o PM2 passou a falhar ao subir o ms-simulado:

```
PM2 error: Script not found: /var/www/main.js
```

## Causa raiz

O `ms.dockerfile` faz `COPY dist ./` para `/var/www` e o PM2 roda `/var/www/main.js` — ou seja, o build precisa gerar `dist/main.js`.

O commit `f3f81b2` (PR #160) adicionou `scripts/backfill-criador-id.ts` na **raiz** do projeto. Como o `tsconfig.build.json` não excluía `scripts/`, esse arquivo entrou na compilação e mudou o `rootDir` inferido pelo tsc de `src/` para a raiz do projeto. A saída passou a ser `dist/src/main.js` + `dist/scripts/…`, então após o `COPY dist ./` o arquivo virou `/var/www/src/main.js` e `/var/www/main.js` deixou de existir.

Começou a quebrar no deploy de homol após o merge do PR #160 (`5244377`).

## Correção

Adiciona `scripts` ao `exclude` do `tsconfig.build.json`. O `rootDir` volta a ser `src/` e o build volta a gerar `dist/main.js`. O backfill continua rodando via `ts-node scripts/backfill-criador-id.ts` (não precisa ir para o `dist`).

## Test plan

- [x] `yarn build` gera `dist/main.js` na raiz do `dist/` (verificado localmente)
- [ ] Deploy de homol sobe sem `Script not found: /var/www/main.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)